### PR TITLE
nodemon looping fix and exec updates

### DIFF
--- a/defaults/_lib/helpers.js
+++ b/defaults/_lib/helpers.js
@@ -1,7 +1,0 @@
-export const execCallback = (err) => {
-  if (err !== null) { throw err; }
-};
-
-export const fspCallback = (err) => {
-  if (err) { throw err; }
-};

--- a/defaults/_lib/pages.js
+++ b/defaults/_lib/pages.js
@@ -1,10 +1,9 @@
-import { exec } from 'child_process';
+import { execSync } from 'child_process';
 import fsp from 'fs-promise';
 import React from 'react';
 import { renderToString } from 'react-dom/server';
 import { match, RoutingContext } from 'react-router';
 import routes from '../src/components/routes';
-import { execCallback, fspCallback } from './helpers';
 
 const buildPages = async () => {
   const allRoutes = [].concat(routes.indexRoute || []).concat(routes.childRoutes || []);
@@ -37,8 +36,9 @@ const matchAndWrite = ({ path }) => {
             directory = determineDirectory(path),
             filePath = path || 'index.html';
 
-      await exec(`mkdir -p _site/${directory}`, execCallback);
-      fsp.writeFile(`_site/${filePath}`, `<!DOCTYPE html>${componentHTML}`, 'utf8', fspCallback);
+      execSync(`mkdir -p _site/${directory}`, { stdio: [0,1,2] });
+      fsp.writeFile(`_site/${filePath}`, `<!DOCTYPE html>${componentHTML}`, 'utf8', (err) => { if (err) { throw err; } });
+
     } catch(e) {
       console.error(e);
     }

--- a/defaults/index.js
+++ b/defaults/index.js
@@ -1,9 +1,8 @@
-import { exec } from 'child_process';
+import { execSync } from 'child_process';
 import express from 'express';
 import { clientJS, port } from './config';
 import buildPages from './_lib/pages';
 import buildClientJS from './_lib/client';
-import { execCallback } from './_lib/helpers';
 
 async () => {
   try {
@@ -12,8 +11,8 @@ async () => {
     /*
      * Remove and recreate _site build folder
      */
-    exec('rm -rf _site', execCallback);
-    exec('mkdir _site', execCallback);
+    execSync('rm -rf _site');
+    execSync('mkdir _site');
 
     /*
      * Build the static pages.

--- a/defaults/nodemon.json
+++ b/defaults/nodemon.json
@@ -1,0 +1,10 @@
+{
+  "verbose": true,
+  "script": "index.js",
+  "exec": "npm run build",
+  "ignore": [
+    "_site/*",
+    "*.log"
+  ],
+  "ext": "js json"
+}

--- a/defaults/package.json
+++ b/defaults/package.json
@@ -2,7 +2,8 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint src",
-    "dev": "npm run lint && babel-node --optional es7.asyncFunctions --stage 0 -- index.js"
+    "dev": "nodemon",
+    "build": "babel-node --optional es7.asyncFunctions --stage 0"
   },
   "devDependencies": {
     "babel": "^5.8.29",
@@ -13,6 +14,7 @@
     "express": "^4.13.3",
     "fs-promise": "^0.3.1",
     "gulp": "^3.9.0",
+    "nodemon": "^1.8.1",
     "uglify-js": "^2.5.0",
     "vinyl-source-stream": "^1.1.0"
   },

--- a/index.js
+++ b/index.js
@@ -13,43 +13,32 @@ var _commander = require('commander');
 
 var _commander2 = _interopRequireDefault(_commander);
 
-var _nodemon = require('nodemon');
-
-var _nodemon2 = _interopRequireDefault(_nodemon);
-
 var _packageJson = require('./package.json');
 
 var _packageJson2 = _interopRequireDefault(_packageJson);
 
 var defaultsPath = _path2['default'].join(__dirname, 'defaults/');
 var execCallback = function execCallback(err) {
-  if (err !== null) {
+  console.log(err);if (err !== null) {
     throw err;
   }
 };
 
-_commander2['default'].command('new [path]').description('create a new react-static project').action(function handleNew(env, options) {
-  if (env) {
-    console.log('Installing react-static in to `' + env + '`');
-    (0, _child_process.exec)('mkdir -p ' + env, execCallback);
-    (0, _child_process.exec)('cp -r ' + defaultsPath + ' ' + env, execCallback);
-    console.log('=> Successfully installed in to `' + env + '`');
-    console.log('=> Run the following to complete setup:\n\n    $ cd ' + env + ' && npm install\n');
+_commander2['default'].command('new [path]').description('create a new react-static project').action(function handleNew(path, options) {
+  if (path) {
+    console.log('Installing react-static in to `' + path + '`');
+    (0, _child_process.execSync)('mkdir -p ' + path);
+    (0, _child_process.execSync)('cp -r ' + defaultsPath + ' ' + path);
+    console.log('=> Successfully installed in to `' + path + '`');
+    console.log('=> Run the following to complete setup:\n\n    $ cd ' + path + ' && npm install\n');
     console.log('=> Once setup is complete, to run the development server:\n\n    $ react-static serve');
   } else {
     console.error('Error: Please provide a directory name to `react-static new <dirname>`');
   }
 });
 
-_commander2['default'].command('serve').description('run the development server and have it watch for changes').option('-m, --main <main>', 'Main entry file (defaults to index.js)').action(function handleServe(_ref) {
-  var _ref$main = _ref.main;
-  var main = _ref$main === undefined ? 'index.js' : _ref$main;
-
-  (0, _nodemon2['default'])({
-    script: main,
-    exec: 'npm run dev',
-    ignore: '_site'
-  });
+_commander2['default'].command('serve').description('run the development server and have it watch for changes').action(function handleServe() {
+  (0, _child_process.execSync)('node_modules/.bin/nodemon', { stdio: [0, 1, 2] });
 });
 
 _commander2['default'].version(_packageJson2['default'].version).parse(process.argv);

--- a/lib/react-static.js
+++ b/lib/react-static.js
@@ -1,24 +1,23 @@
 #!/usr/bin/env node
 
 import path from 'path';
-import { exec } from 'child_process';
+import { execSync } from 'child_process';
 import program from 'commander';
-import nodemon from 'nodemon';
 import pkg from './package.json';
 
 const defaultsPath = path.join(__dirname, 'defaults/');
-const execCallback = (err) => { if (err !== null) { throw err; } };
+const execCallback = (err) => { console.log(err); if (err !== null) { throw err; } };
 
 program
   .command('new [path]')
   .description('create a new react-static project')
-  .action(function handleNew(env, options) {
-    if (env) {
-      console.log(`Installing react-static in to \`${env}\``);
-      exec(`mkdir -p ${env}`, execCallback);
-      exec(`cp -r ${defaultsPath} ${env}`, execCallback);
-      console.log(`=> Successfully installed in to \`${env}\``);
-      console.log(`=> Run the following to complete setup:\n\n    $ cd ${env} && npm install\n`);
+  .action(function handleNew(path, options) {
+    if (path) {
+      console.log(`Installing react-static in to \`${path}\``);
+      execSync(`mkdir -p ${path}`);
+      execSync(`cp -r ${defaultsPath} ${path}`);
+      console.log(`=> Successfully installed in to \`${path}\``);
+      console.log(`=> Run the following to complete setup:\n\n    $ cd ${path} && npm install\n`);
       console.log('=> Once setup is complete, to run the development server:\n\n    $ react-static serve');
     } else {
       console.error('Error: Please provide a directory name to `react-static new <dirname>`');
@@ -28,13 +27,8 @@ program
 program
   .command('serve')
   .description('run the development server and have it watch for changes')
-  .option('-m, --main <main>', 'Main entry file (defaults to index.js)')
-  .action(function handleServe({ main = 'index.js' }) {
-    nodemon({
-      script: main,
-      exec: 'npm run dev',
-      ignore: '_site'
-    });
+  .action(function handleServe() {
+    execSync('node_modules/.bin/nodemon', { stdio: [0,1,2] });
   });
 
 program

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "babel": "^5.8.29",
-    "commander": "^2.9.0",
-    "nodemon": "^1.8.1"
+    "commander": "^2.9.0"
   },
   "devDependencies": {
     "babel-eslint": "^4.1.4",


### PR DESCRIPTION
This is a fix for #9.
- Moves Nodemon from being a dependency of and executed on `react-static` to being part of the defaults
- Enables nodemon logging output
- includes a `nodemon.json` file in the `defaults/` for flexibility of usage (extensions, etc)
